### PR TITLE
Issue with PodSpec

### DIFF
--- a/PaymentKit.podspec
+++ b/PaymentKit.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source              = { :git => "https://github.com/stripe/PaymentKit.git", :tag => "v1.0.0"}
   s.source_files        = 'PaymentKit/*.{h,m}'
   s.public_header_files = 'PaymentKit/*.h'
-  s.resources           = 'PaymentKit/Resources'
+  s.resources           = 'PaymentKit/Resources/Cards/*.png'
   s.platform            = :ios
   s.requires_arc        = true
 end


### PR DESCRIPTION
Hey Alex,

I hit an issue when upgrading to your latest version - as documented here: https://github.com/CocoaPods/CocoaPods/issues/800

I've tested updating the podspec to reference 'Resources/Cards/*.png' instead of 'Resources' and this fixes the issue I was seeing.

Hence my pull request.

Thanks,
Chris
