### PR TITLE
Implement UIResponder methods

### DIFF
--- a/PaymentKit/PKView.m
+++ b/PaymentKit/PKView.m
@@ -31,6 +31,7 @@
 
 @property (nonatomic, readonly, assign) UIResponder *firstResponderField;
 @property (nonatomic, readonly, assign) PKTextField *firstInvalidField;
+@property (nonatomic, readonly, assign) PKTextField *nextFirstResponder;
 
 - (void)setup;
 - (void)setupPlaceholderView;
@@ -542,6 +543,14 @@
     return nil;
 }
 
+- (PKTextField *)nextFirstResponder;
+{
+    if (self.firstInvalidField)
+        return self.firstInvalidField;
+    
+    return self.cardCVCField;
+}
+
 - (BOOL)isFirstResponder;
 {
     return self.firstResponderField.isFirstResponder;
@@ -549,12 +558,12 @@
 
 - (BOOL)canBecomeFirstResponder;
 {
-    return self.firstInvalidField.canBecomeFirstResponder;
+    return self.nextFirstResponder.canBecomeFirstResponder;
 }
 
 - (BOOL)becomeFirstResponder;
 {
-    return [self.firstInvalidField becomeFirstResponder];
+    return [self.nextFirstResponder becomeFirstResponder];
 }
 
 - (BOOL)canResignFirstResponder;


### PR DESCRIPTION
Implement the UIResponder methods. 
- `becomeFirstResponder` will find the first invalid text field and makes it the first responder
- `resignFirstResponder` will resign the currently active field as first responder
- `canBecomeFirstResponder` will return the first invalid text field's return value for the same method
- `isFirstResponder` and `canResignFirstResponder` return the currently active fields return value for the same methods
