### PR TITLE
Properly declaring the PKTextField delegate method to fix #21

### DIFF
--- a/PaymentKit/PKTextField.h
+++ b/PaymentKit/PKTextField.h
@@ -10,8 +10,19 @@
 
 @class PKTextField;
 
+@protocol PKTextFieldDelegate <UITextFieldDelegate>
+
+@optional
+
+- (void)pkTextFieldDidBackSpaceWhileTextIsEmpty:(PKTextField *)textField;
+
+@end
+
 @interface PKTextField : UITextField
 
 + (NSString*)textByRemovingUselessSpacesFromString:(NSString*)string;
 
+@property (nonatomic, weak) id<PKTextFieldDelegate> delegate;
+
 @end
+

--- a/PaymentKit/PKView.m
+++ b/PaymentKit/PKView.m
@@ -22,7 +22,7 @@
 #import "PKView.h"
 #import "PKTextField.h"
 
-@interface PKView () <UITextFieldDelegate> {
+@interface PKView () <PKTextFieldDelegate> {
 @private
     BOOL _isInitialState;
     BOOL _isValidState;


### PR DESCRIPTION
Issue #21 wasn't properly fixed by 54361a7 as `PKTextField.m` doesn't import `PKView.h`.
