### PR TITLE
PTKView will not become first responder by default

### DIFF
--- a/PaymentKit Example/PaymentKit Example/PaymentViewController.m
+++ b/PaymentKit Example/PaymentKit Example/PaymentViewController.m
@@ -37,6 +37,7 @@
     self.paymentView.delegate = self;
     
     [self.view addSubview:self.paymentView];
+    [self.paymentView becomeFirstResponder];
 }
 
 

--- a/PaymentKit/PTKTextField.m
+++ b/PaymentKit/PTKTextField.m
@@ -12,6 +12,8 @@
 
 @implementation PTKTextField
 
+@dynamic delegate;
+
 + (NSString *)textByRemovingUselessSpacesFromString:(NSString *)string
 {
     return [string stringByReplacingOccurrencesOfString:kPTKTextFieldSpaceChar withString:@""];

--- a/PaymentKit/PTKView.m
+++ b/PaymentKit/PTKView.m
@@ -230,9 +230,8 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
                              [self.cardExpiryField removeFromSuperview];
                              [self.cardCVCField removeFromSuperview];
                          }];
+        [self.cardNumberField becomeFirstResponder];
     }
-
-    [self.cardNumberField becomeFirstResponder];
 }
 
 - (void)stateMeta


### PR DESCRIPTION
Per issue #48. Example has been updated to call `becomeFirstResponder` instead.