### PR TITLE
Improve customizability of PTKView

### DIFF
--- a/PaymentKit/PTKView.h
+++ b/PaymentKit/PTKView.h
@@ -25,6 +25,8 @@
 
 - (BOOL)isValid;
 
+- (void)checkValid;
+
 @property (nonatomic, readonly) PTKCardNumber *cardNumber;
 @property (nonatomic, readonly) PTKCardExpiry *cardExpiry;
 @property (nonatomic, readonly) PTKCardCVC *cardCVC;

--- a/PaymentKit/PTKView.h
+++ b/PaymentKit/PTKView.h
@@ -25,14 +25,19 @@
 
 - (BOOL)isValid;
 
-@property (nonatomic, readonly) UIView *opaqueOverGradientView;
 @property (nonatomic, readonly) PTKCardNumber *cardNumber;
 @property (nonatomic, readonly) PTKCardExpiry *cardExpiry;
 @property (nonatomic, readonly) PTKCardCVC *cardCVC;
 @property (nonatomic, readonly) PTKAddressZip *addressZip;
 
+@property (strong, nonatomic) UIFont *defaultFont;
+@property (strong, nonatomic) UIColor *textColor, *textErrorColor;
+@property (assign, nonatomic) UIEdgeInsets contentInsets;
+
 @property IBOutlet UIView *innerView;
-@property IBOutlet UIView *clipView;
+@property IBOutlet UIView *separatorView;
+@property IBOutlet UIImageView *backgroundImageView;
+
 @property IBOutlet PTKTextField *cardNumberField;
 @property IBOutlet PTKTextField *cardExpiryField;
 @property IBOutlet PTKTextField *cardCVCField;

--- a/PaymentKit/PTKView.h
+++ b/PaymentKit/PTKView.h
@@ -35,6 +35,7 @@
 @property (strong, nonatomic) UIFont *defaultFont;
 @property (strong, nonatomic) UIColor *textColor, *textErrorColor;
 @property (assign, nonatomic) UIEdgeInsets contentInsets;
+@property (assign, nonatomic) BOOL showingMeta;
 
 @property IBOutlet UIView *innerView;
 @property IBOutlet UIView *separatorView;

--- a/PaymentKit/PTKView.m
+++ b/PaymentKit/PTKView.m
@@ -7,17 +7,10 @@
 //
 
 #define RGB(r,g,b) [UIColor colorWithRed:r/255.0f green:g/255.0f blue:b/255.0f alpha:1.0f]
-#define DarkGreyColor RGB(0,0,0)
-#define RedColor RGB(253,0,17)
-#define DefaultBoldFont [UIFont boldSystemFontOfSize:17]
 
 #define kPTKViewPlaceholderViewAnimationDuration 0.25
 
-#define kPTKViewCardExpiryFieldStartX 84 + 200
-#define kPTKViewCardCVCFieldStartX 177 + 200
-
-#define kPTKViewCardExpiryFieldEndX 84
-#define kPTKViewCardCVCFieldEndX 177
+static CGFloat const kIconWidth = 32, kIconHeight = 20;
 
 static NSString *const kPTKLocalizedStringsTableName = @"PaymentKit";
 static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable";
@@ -37,9 +30,6 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 
 - (void)setup;
 - (void)setupPlaceholderView;
-- (void)setupCardNumberField;
-- (void)setupCardExpiryField;
-- (void)setupCardCVCField;
 
 - (void)pkTextFieldDidBackSpaceWhileTextIsEmpty:(PTKTextField *)textField;
 
@@ -48,7 +38,6 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 - (BOOL)cardExpiryShouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)replacementString;
 - (BOOL)cardCVCShouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)replacementString;
 
-@property (nonatomic) UIView *opaqueOverGradientView;
 @property (nonatomic) PTKCardNumber *cardNumber;
 @property (nonatomic) PTKCardExpiry *cardExpiry;
 @property (nonatomic) PTKCardCVC *cardCVC;
@@ -58,6 +47,11 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 #pragma mark -
 
 @implementation PTKView
+
+- (id)init
+{
+    return [self initWithFrame:CGRectMake(0, 0, 290, 46)];
+}
 
 - (id)initWithFrame:(CGRect)frame
 {
@@ -79,87 +73,162 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
     _isInitialState = YES;
     _isValidState = NO;
 
-    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, 290, 46);
     self.backgroundColor = [UIColor clearColor];
 
-    UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:self.bounds];
-    backgroundImageView.image = [[UIImage imageNamed:@"textfield"]
-            resizableImageWithCapInsets:UIEdgeInsetsMake(0, 8, 0, 8)];
-    [self addSubview:backgroundImageView];
+    _backgroundImageView = [UIImageView new];
+    _backgroundImageView.image = [[UIImage imageNamed:@"textfield"]
+                                  resizableImageWithCapInsets:UIEdgeInsetsMake(0, 8, 0, 8)
+                                  resizingMode:UIImageResizingModeStretch];
+    [self addSubview:_backgroundImageView];
 
-    self.innerView = [[UIView alloc] initWithFrame:CGRectMake(40, 12, self.frame.size.width - 40, 20)];
-    self.innerView.clipsToBounds = YES;
+    _innerView = [UIView new];
+    _innerView.clipsToBounds = YES;
+
+    _cardNumberField = [PTKTextField new];
+    _cardExpiryField = [PTKTextField new];
+    _cardCVCField = [PTKTextField new];
+
+    _cardNumberField.placeholder = [self.class localizedStringWithKey:@"placeholder.card_number" defaultValue:@"1234 5678 9012 3456"];
+    _cardExpiryField.placeholder = [self.class localizedStringWithKey:@"placeholder.card_expiry" defaultValue:@"MM/YY"];
+    _cardCVCField.placeholder = [self.class localizedStringWithKey:@"placeholder.card_cvc" defaultValue:@"CVC"];
+
+    for (PTKTextField *field in @[_cardNumberField, _cardExpiryField, _cardCVCField]) {
+        field.delegate = self;
+        field.keyboardType = UIKeyboardTypeNumberPad;
+        field.layer.masksToBounds = YES;
+    }
+
+    [_innerView addSubview:self.cardNumberField];
+
+    _separatorView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"gradient"]];
+    _separatorView.frame = CGRectMake(0, 0, 12, self.frame.size.height);
+    [_innerView addSubview:_separatorView];
+
+    [self addSubview:_innerView];
 
     [self setupPlaceholderView];
-    [self setupCardNumberField];
-    [self setupCardExpiryField];
-    [self setupCardCVCField];
-
-    [self.innerView addSubview:self.cardNumberField];
-
-    UIImageView *gradientImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 12, 34)];
-    gradientImageView.image = [UIImage imageNamed:@"gradient"];
-    [self.innerView addSubview:gradientImageView];
-
-    self.opaqueOverGradientView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 9, 34)];
-    self.opaqueOverGradientView.backgroundColor = [UIColor colorWithRed:0.9686 green:0.9686
-                                                                   blue:0.9686 alpha:1.0000];
-    self.opaqueOverGradientView.alpha = 0.0;
-    [self.innerView addSubview:self.opaqueOverGradientView];
-
-    [self addSubview:self.innerView];
-    [self addSubview:self.placeholderView];
+    [self addSubview:_placeholderView];
 
     [self stateCardNumber];
-}
 
+    self.textColor = RGB(0, 0, 0);
+    self.textErrorColor = RGB(253, 0, 17);
+    self.defaultFont = [UIFont boldSystemFontOfSize:17];
+    self.contentInsets = UIEdgeInsetsMake(12, 12, 12, 12);
+}
 
 - (void)setupPlaceholderView
 {
-    self.placeholderView = [[UIImageView alloc] initWithFrame:CGRectMake(12, 13, 32, 20)];
-    self.placeholderView.backgroundColor = [UIColor clearColor];
-    self.placeholderView.image = [UIImage imageNamed:@"placeholder"];
+    _placeholderView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"placeholder"]];
+    _placeholderView.backgroundColor = [UIColor clearColor];
 
     CALayer *clip = [CALayer layer];
-    clip.frame = CGRectMake(32, 0, 4, 20);
+    clip.frame = CGRectMake(kIconWidth, 0, 4, kIconHeight);
     clip.backgroundColor = [UIColor clearColor].CGColor;
-    [self.placeholderView.layer addSublayer:clip];
+    [_placeholderView.layer addSublayer:clip];
 }
 
-- (void)setupCardNumberField
-{
-    self.cardNumberField = [[PTKTextField alloc] initWithFrame:CGRectMake(12, 0, 170, 20)];
-    self.cardNumberField.delegate = self;
-    self.cardNumberField.placeholder = [self.class localizedStringWithKey:@"placeholder.card_number" defaultValue:@"1234 5678 9012 3456"];
-    self.cardNumberField.keyboardType = UIKeyboardTypeNumberPad;
-    self.cardNumberField.textColor = DarkGreyColor;
-    self.cardNumberField.font = DefaultBoldFont;
+#pragma mark - Layout
 
-    [self.cardNumberField.layer setMasksToBounds:YES];
+- (void)layoutSubviews
+{
+    self.backgroundImageView.frame = self.bounds;
+    CGRect insetBounds = UIEdgeInsetsInsetRect(self.bounds, self.contentInsets);
+
+    self.placeholderView.frame = CGRectMake(insetBounds.origin.x,
+                                            insetBounds.origin.y + (insetBounds.size.height - kIconHeight)/2,
+                                            kIconWidth, kIconHeight);
+
+    CGFloat innerViewOffset = CGRectGetMaxX(self.placeholderView.frame) + self.contentInsets.left;
+    self.innerView.frame = CGRectMake(innerViewOffset,
+                                      insetBounds.origin.y,
+                                      insetBounds.size.width - innerViewOffset,
+                                      insetBounds.size.height);
+
+    self.cardNumberField.frame = [self cardNumberFrame];
+    self.cardExpiryField.frame = [self cardExpiryFrame];
+    self.cardCVCField.frame = [self cardCVCFrame];
 }
 
-- (void)setupCardExpiryField
+- (CGRect)cardExpiryFrame
 {
-    self.cardExpiryField = [[PTKTextField alloc] initWithFrame:CGRectMake(kPTKViewCardExpiryFieldStartX, 0, 60, 20)];
-    self.cardExpiryField.delegate = self;
-    self.cardExpiryField.placeholder = [self.class localizedStringWithKey:@"placeholder.card_expiry" defaultValue:@"MM/YY"];
-    self.cardExpiryField.keyboardType = UIKeyboardTypeNumberPad;
-    self.cardExpiryField.textColor = DarkGreyColor;
-    self.cardExpiryField.font = DefaultBoldFont;
-
-    [self.cardExpiryField.layer setMasksToBounds:YES];
+    CGSize size = [self textSize:@"MM/MM"];
+    CGFloat offset = (self.innerView.bounds.size.width - size.width)/2;
+    if(_isInitialState) {
+        offset += self.innerView.bounds.size.width;
+    }
+    CGFloat marginY = (self.innerView.bounds.size.height - size.height)/2;
+    return CGRectMake(offset, marginY, size.width, size.height);
 }
 
-- (void)setupCardCVCField
+- (CGRect)cardCVCFrame
 {
-    self.cardCVCField = [[PTKTextField alloc] initWithFrame:CGRectMake(kPTKViewCardCVCFieldStartX, 0, 55, 20)];
-    self.cardCVCField.delegate = self;
-    self.cardCVCField.placeholder = [self.class localizedStringWithKey:@"placeholder.card_cvc" defaultValue:@"CVC"];
-    self.cardCVCField.keyboardType = UIKeyboardTypeNumberPad;
-    self.cardCVCField.textColor = DarkGreyColor;
-    self.cardCVCField.font = DefaultBoldFont;
+    CGSize size = [self textSize:@"MMMM"];
+    CGFloat offset = self.innerView.bounds.size.width - size.width;
+    if(_isInitialState) {
+        offset += self.innerView.bounds.size.width;
+    }
+    CGFloat marginY = (self.innerView.bounds.size.height - size.height)/2;
+    return CGRectMake(offset, marginY, size.width, size.height);
+}
 
-    [self.cardCVCField.layer setMasksToBounds:YES];
+- (CGRect)cardNumberFrame
+{
+    CGSize size = [self textSize:@"MMMM MMMM MMMM MMMM"];
+    CGFloat offset = CGRectGetMaxX(self.separatorView.frame);
+    size.width = MAX(size.width, self.innerView.bounds.size.width - offset);
+    if(!_isInitialState) {
+        CGFloat cardNumberWidth = [self textSize:self.cardNumber.formattedString].width;
+        CGFloat lastGroupWidth = [self textSize:self.cardNumber.lastGroup].width;
+
+        offset -= (cardNumberWidth - lastGroupWidth);
+    }
+    CGFloat marginY = (self.innerView.bounds.size.height - size.height)/2;
+    return CGRectMake(offset, marginY, size.width, size.height);
+}
+
+#pragma mark - Settings
+
+- (void)setTextColor:(UIColor *)textColor
+{
+    _textColor = textColor;
+    for(PTKTextField *field in @[self.cardCVCField, self.cardExpiryField, self.cardNumberField]) {
+        field.textColor = textColor;
+    }
+}
+
+- (void)setDefaultFont:(UIFont *)defaultFont
+{
+    _defaultFont = defaultFont;
+    for(PTKTextField *field in @[self.cardCVCField, self.cardExpiryField, self.cardNumberField]) {
+        field.font = defaultFont;
+    }
+}
+
+- (void)setSeparatorView:(UIView *)separatorView
+{
+    [_separatorView removeFromSuperview];
+    _separatorView = separatorView;
+    [_innerView addSubview:separatorView];
+    [self setNeedsLayout];
+}
+
+- (void)setContentInsets:(UIEdgeInsets)contentInsets
+{
+    _contentInsets = contentInsets;
+    [self setNeedsLayout];
+}
+
+#pragma mark - Helpers
+
+- (CGSize)textSize:(NSString*)str
+{
+    if ([str respondsToSelector:@selector(sizeWithAttributes:)]) {
+        NSDictionary *attributes = @{NSFontAttributeName: self.defaultFont};
+        return [str sizeWithAttributes:attributes];
+    } else {
+        return [str sizeWithFont:self.defaultFont];
+    }
 }
 
 // Checks both the old and new localization table (we switched in 3/14 to PaymentKit.strings).
@@ -204,27 +273,11 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
         // Animate left
         _isInitialState = YES;
 
-        [UIView animateWithDuration:0.05 delay:0.0 options:UIViewAnimationOptionCurveEaseInOut
-                         animations:^{
-                             self.opaqueOverGradientView.alpha = 0.0;
-                         } completion:^(BOOL finished) {
-        }];
         [UIView animateWithDuration:0.400
                               delay:0
                             options:(UIViewAnimationOptionCurveEaseInOut | UIViewAnimationOptionAllowUserInteraction)
                          animations:^{
-                             self.cardExpiryField.frame = CGRectMake(kPTKViewCardExpiryFieldStartX,
-                                     self.cardExpiryField.frame.origin.y,
-                                     self.cardExpiryField.frame.size.width,
-                                     self.cardExpiryField.frame.size.height);
-                             self.cardCVCField.frame = CGRectMake(kPTKViewCardCVCFieldStartX,
-                                     self.cardCVCField.frame.origin.y,
-                                     self.cardCVCField.frame.size.width,
-                                     self.cardCVCField.frame.size.height);
-                             self.cardNumberField.frame = CGRectMake(12,
-                                     self.cardNumberField.frame.origin.y,
-                                     self.cardNumberField.frame.size.width,
-                                     self.cardNumberField.frame.size.height);
+                             [self layoutSubviews];
                          }
                          completion:^(BOOL completed) {
                              [self.cardExpiryField removeFromSuperview];
@@ -239,51 +292,14 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 {
     _isInitialState = NO;
 
-    CGSize cardNumberSize;
-    CGSize lastGroupSize;
-
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0
-    if ([self.cardNumber.formattedString respondsToSelector:@selector(sizeWithAttributes:)]) {
-        NSDictionary *attributes = @{NSFontAttributeName: DefaultBoldFont};
-
-        cardNumberSize = [self.cardNumber.formattedString sizeWithAttributes:attributes];
-        lastGroupSize = [self.cardNumber.lastGroup sizeWithAttributes:attributes];
-    } else {
-        cardNumberSize = [self.cardNumber.formattedString sizeWithFont:DefaultBoldFont];
-        lastGroupSize = [self.cardNumber.lastGroup sizeWithFont:DefaultBoldFont];
-    }
-#else
-    NSDictionary *attributes = @{NSFontAttributeName: DefaultBoldFont};
-
-    cardNumberSize = [self.cardNumber.formattedString sizeWithAttributes:attributes];
-    lastGroupSize = [self.cardNumber.lastGroup sizeWithAttributes:attributes];
-#endif
-
-    CGFloat frameX = self.cardNumberField.frame.origin.x - (cardNumberSize.width - lastGroupSize.width);
-
-    [UIView animateWithDuration:0.05 delay:0.35 options:UIViewAnimationOptionCurveEaseInOut
-                     animations:^{
-                         self.opaqueOverGradientView.alpha = 1.0;
-                     } completion:^(BOOL finished) {
-    }];
-    [UIView animateWithDuration:0.400 delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-        self.cardExpiryField.frame = CGRectMake(kPTKViewCardExpiryFieldEndX,
-                self.cardExpiryField.frame.origin.y,
-                self.cardExpiryField.frame.size.width,
-                self.cardExpiryField.frame.size.height);
-        self.cardCVCField.frame = CGRectMake(kPTKViewCardCVCFieldEndX,
-                self.cardCVCField.frame.origin.y,
-                self.cardCVCField.frame.size.width,
-                self.cardCVCField.frame.size.height);
-        self.cardNumberField.frame = CGRectMake(frameX,
-                self.cardNumberField.frame.origin.y,
-                self.cardNumberField.frame.size.width,
-                self.cardNumberField.frame.size.height);
-    }                completion:nil];
-
     [self addSubview:self.placeholderView];
     [self.innerView addSubview:self.cardExpiryField];
     [self.innerView addSubview:self.cardCVCField];
+
+    [UIView animateWithDuration:0.400 delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+        [self layoutSubviews];
+    }                completion:nil];
+
     [self.cardExpiryField becomeFirstResponder];
 }
 
@@ -528,16 +544,16 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 
 - (void)textFieldIsValid:(UITextField *)textField
 {
-    textField.textColor = DarkGreyColor;
+    textField.textColor = self.textColor;
     [self checkValid];
 }
 
 - (void)textFieldIsInvalid:(UITextField *)textField withErrors:(BOOL)errors
 {
     if (errors) {
-        textField.textColor = RedColor;
+        textField.textColor = self.textErrorColor;
     } else {
-        textField.textColor = DarkGreyColor;
+        textField.textColor = self.textColor;
     }
 
     [self checkValid];

--- a/PaymentKit/PTKView.m
+++ b/PaymentKit/PTKView.m
@@ -526,18 +526,12 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 
 - (void)checkValid
 {
-    if ([self isValid]) {
-        _isValidState = YES;
+    BOOL isValid = self.isValid;
+    if(isValid || isValid != _isValidState) {
+        _isValidState = isValid;
 
         if ([self.delegate respondsToSelector:@selector(paymentView:withCard:isValid:)]) {
-            [self.delegate paymentView:self withCard:self.card isValid:YES];
-        }
-
-    } else if (![self isValid] && _isValidState) {
-        _isValidState = NO;
-
-        if ([self.delegate respondsToSelector:@selector(paymentView:withCard:isValid:)]) {
-            [self.delegate paymentView:self withCard:self.card isValid:NO];
+            [self.delegate paymentView:self withCard:self.card isValid:isValid];
         }
     }
 }


### PR DESCRIPTION
This pull request cleans up `PTKView` and adds the following features:

1. Size-independent layout. You should be able to specify any reasonably-sized frame and PTKView will attempt to lay out in that area, rather than having hardcoded sizes everywhere with no layout code.
2. Configurable font and font colors.
3. Ability to override `backgroundImageView`.
4. Ability to supply a custom `separatorView` (e.g. for a vertical line instead of a gradient).
5. Ability to supply custom padding via `contentInsets`.

The defaults should be the same, but please let me know if you notice any differences.

This work was done because we had a design for which `PTKView` was a great fit, however I was forced with the choices of: forking off our own and customizing it heavily; writing our own replacement; or updating `PTKView` as in this PR to allow customization hooks in the hopes that others will find it useful.