### PR TITLE
NSCalendar identifiers and components updated for iOS8

### DIFF
--- a/PaymentKit/PTKCardExpiry.m
+++ b/PaymentKit/PTKCardExpiry.m
@@ -97,8 +97,8 @@
 
 - (BOOL)isValidWithDate:(NSDate *)dateToCompare
 {
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-    NSDateComponents *components = [gregorian components:NSYearCalendarUnit | NSMonthCalendarUnit fromDate:dateToCompare];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSDateComponents *components = [gregorian components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:dateToCompare];
     BOOL valid = NO;
 
     if (components.year < self.year) {
@@ -128,7 +128,7 @@
 
     static NSCalendar *gregorian = nil;
     if (!gregorian) {
-        gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+        gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     }
 
     // Move to the last day of the month.


### PR DESCRIPTION
Was getting compiler warnings for NSCalendar related identifiers and components in iOS8