### PR TITLE
Implementing intrinsicContentSize

### DIFF
--- a/PaymentKit/PTKView.m
+++ b/PaymentKit/PTKView.m
@@ -19,6 +19,8 @@
 #define kPTKViewCardExpiryFieldEndX 84
 #define kPTKViewCardCVCFieldEndX 177
 
+#define kPTKViewDefaultSize CGSizeMake(290, 46)
+
 static NSString *const kPTKLocalizedStringsTableName = @"PaymentKit";
 static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable";
 
@@ -79,7 +81,7 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
     _isInitialState = YES;
     _isValidState = NO;
 
-    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, 290, 46);
+    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, kPTKViewDefaultSize.width, kPTKViewDefaultSize.height);
     self.backgroundColor = [UIColor clearColor];
 
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:self.bounds];
@@ -602,6 +604,14 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
     [super resignFirstResponder];
     
     return [self.firstResponderField resignFirstResponder];
+}
+
+#pragma mark -
+#pragma mark UIView
+
+- (CGSize)intrinsicContentSize
+{
+    return kPTKViewDefaultSize;
 }
 
 @end


### PR DESCRIPTION
`-intrinsicContentSize` allows for the `PTKView` to be used properly in auto layout without having to resort to explicit dimension constraints. Currently, centering `PTKView` without providing a size can result in strange layouts (ultimately due to the fact that the `PTKView` does not determine its own size by the sizing of its subviews). An example of such a layout can be seen in the following screen shot:
![screen shot 2015-02-09 at 11 06 52 am](https://cloud.githubusercontent.com/assets/4359198/6115054/91fbf9bc-b057-11e4-84e3-f397ce1d1fbf.png)
(Here, the thin, centered grey line is the `PTKView`)

Implementing `-intrinsicContentSize` fixes this.