### PR TITLE
Don't show keyboard when PTKView is hidden

### DIFF
--- a/PaymentKit/PTKView.m
+++ b/PaymentKit/PTKView.m
@@ -232,7 +232,9 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
                          }];
     }
 
-    [self.cardNumberField becomeFirstResponder];
+    if (!self.hidden) {
+        [self.cardNumberField becomeFirstResponder];
+    }
 }
 
 - (void)stateMeta
@@ -600,7 +602,7 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 - (BOOL)resignFirstResponder;
 {
     [super resignFirstResponder];
-    
+
     return [self.firstResponderField resignFirstResponder];
 }
 


### PR DESCRIPTION
I have a PTKView in a storyboard, which is hidden until required.  However, the number entry keyboard is still shown.  Here I've added a check to make sure the PTKView is visible before calling `#becomeFirstResponder`.