### PR TITLE
Fix two crashes in PTKCardNumber's cardType accessor

### DIFF
--- a/PaymentKit Example/PaymentKit Test/PTKCardNumberTest.m
+++ b/PaymentKit Example/PaymentKit Test/PTKCardNumberTest.m
@@ -28,6 +28,10 @@
     
     XCTAssertEqual([CNUMBER(@"6001270990139424") cardType], PTKCardTypeUnknown, @"Detects Discover");
     XCTAssertEqual([CNUMBER(@"6229260990139424") cardType], PTKCardTypeUnknown, @"Detects Discover");
+
+    // These test two code paths that would previously crash
+    XCTAssertEqual([CNUMBER(@"622") cardType], PTKCardTypeUnknown, @"Detects Discover");
+    XCTAssertEqual([CNUMBER(@"624") cardType], PTKCardTypeUnknown, @"Detects Discover");
 }
 
 - (void)testLast4

--- a/PaymentKit Example/PaymentKit Test/PTKCardNumberTest.m
+++ b/PaymentKit Example/PaymentKit Test/PTKCardNumberTest.m
@@ -30,8 +30,8 @@
     XCTAssertEqual([CNUMBER(@"6229260990139424") cardType], PTKCardTypeUnknown, @"Detects Discover");
 
     // These test two code paths that would previously crash
-    XCTAssertEqual([CNUMBER(@"622") cardType], PTKCardTypeUnknown, @"Detects Discover");
-    XCTAssertEqual([CNUMBER(@"624") cardType], PTKCardTypeUnknown, @"Detects Discover");
+    XCTAssertEqual([CNUMBER(@"622") cardType], PTKCardTypeUnknown, @"Doesn't crash");
+    XCTAssertEqual([CNUMBER(@"624") cardType], PTKCardTypeUnknown, @"Doesn't crash");
 }
 
 - (void)testLast4

--- a/PaymentKit/PTKCardNumber.m
+++ b/PaymentKit/PTKCardNumber.m
@@ -48,23 +48,25 @@
     } else if ([_number hasPrefix:@"6011"] || [_number hasPrefix:@"65"]) {
         return PTKCardTypeDiscover;
     } else if ([_number hasPrefix:@"622"]) {
-        // If 622126-622925 its Discover
-        NSString *sixChars = [_number substringWithRange:NSMakeRange(0, 6)];
-        NSInteger sixCharsInt = [sixChars integerValue];
-        if ((sixCharsInt >= 622126) && (sixCharsInt <= 622925)) {
-            return PTKCardTypeDiscover;
+        // If the number has a prefix in the range 622126-622925, it's Discover
+        NSUInteger prefixLength = 6;
+        if (_number.length >= prefixLength) {
+            NSInteger sixDigitPrefix = [[_number substringWithRange:NSMakeRange(0, prefixLength)] integerValue];
+            if ((sixDigitPrefix >= 622126) && (sixDigitPrefix <= 622925)) {
+                return PTKCardTypeDiscover;
+            }
         }
-        
         return PTKCardTypeUnknown;
-        
     } else if (range == 64) {
-        // If 644-649 its Discover
-        NSInteger discoverCheckInt = [[_number substringWithRange:NSMakeRange(0, 3)] integerValue];
-        if ((discoverCheckInt >= 644) && (discoverCheckInt <= 649)) {
-            return PTKCardTypeDiscover;
+        // If the number has a prefix in the range 644-649, it's Discover
+        NSUInteger prefixLength = 3;
+        if (_number.length >= prefixLength) {
+            NSInteger threeDigitPrefix = [[_number substringWithRange:NSMakeRange(0, prefixLength)] integerValue];
+            if ((threeDigitPrefix >= 644) && (threeDigitPrefix <= 649)) {
+                return PTKCardTypeDiscover;
+            }
         }
         return PTKCardTypeUnknown;
-        
     } else if (range == 35) {
         return PTKCardTypeJCB;
     } else if (range == 30 || range == 36 || range == 38 || range == 39) {


### PR DESCRIPTION
This [change](https://github.com/stripe/PaymentKit/commit/550c9c5cbaa7fb36a90ce599c9e69d1bc5aa0e46) introduced [two sources of crashes](https://github.com/stripe/PaymentKit/commit/58ecff74ac7eb8d5a04b9e90ae3707d3bb1ee4f9).

This PR fixes those.

@ekampf you might want to look at this since it's related to your changes.

Note that there is one other inconsistency which this PR doesn't address (due to my limited knowledge of CC numbers): `-cardType` considers specific number subranges in the 62 and 64 number range. However, `STPCard` does not:

```objective-c
+ (STPCardBrand)cardTypeFromNumber:(NSString *)number {
    if ([number hasPrefix:@"34"] || [number hasPrefix:@"37"]) {
        return STPCardBrandAmex;
    } else if ([number hasPrefix:@"60"] || [number hasPrefix:@"62"] || [number hasPrefix:@"64"] || [number hasPrefix:@"65"]) {
        return STPCardBrandDiscover;
    } else if ([number hasPrefix:@"35"]) {
        return STPCardBrandJCB;
    } else if ([number hasPrefix:@"30"] || [number hasPrefix:@"36"] || [number hasPrefix:@"38"] || [number hasPrefix:@"39"]) {
        return STPCardBrandDinersClub;
    } else if ([number hasPrefix:@"4"]) {
        return STPCardBrandVisa;
    } else if ([number hasPrefix:@"5"]) {
        return STPCardBrandMasterCard;
    } else {
        return STPCardBrandUnknown;
    }
}
```