### PR TITLE
improve isPartiallyValid

### DIFF
--- a/PaymentKit/PTKCardNumber.m
+++ b/PaymentKit/PTKCardNumber.m
@@ -191,7 +191,7 @@
 
 - (BOOL)isPartiallyValid
 {
-    return _number.length <= [self lengthForCardType];
+    return _number.length < [self lengthForCardType];
 }
 
 - (NSInteger)lengthForCardType

--- a/PaymentKit/PTKCardNumber.m
+++ b/PaymentKit/PTKCardNumber.m
@@ -191,7 +191,7 @@
 
 - (BOOL)isPartiallyValid
 {
-    return _number.length < [self lengthForCardType];
+    return [self isValid] || _number.length < [self lengthForCardType];
 }
 
 - (NSInteger)lengthForCardType


### PR DESCRIPTION
A number can't be partially valid if it's already the full length and it's not valid.

With the old implementation you could type 16 invalid Visa digits and `isPartiallyValid` would return `true` even though it's impossible for the number to become valid with the addition of more digits.

P.S. Hi @jflinter 